### PR TITLE
Adding DATA_LENGTH. Removing unused code.

### DIFF
--- a/include/pacmod3/pacmod3_core.h
+++ b/include/pacmod3/pacmod3_core.h
@@ -739,6 +739,8 @@ class SystemCmdBool :
   public Pacmod3RxMsg
 {
 public:
+  static const uint8_t DATA_LENGTH = 2;
+
   void encode(bool enable,
               bool ignore_overrides,
               bool clear_override,
@@ -750,6 +752,8 @@ class SystemCmdFloat :
   public Pacmod3RxMsg
 {
 public:
+  static const uint8_t DATA_LENGTH = 3;
+
   void encode(bool enable,
               bool ignore_overrides,
               bool clear_override,
@@ -761,6 +765,8 @@ class SystemCmdInt :
   public Pacmod3RxMsg
 {
 public:
+  static const uint8_t DATA_LENGTH = 2;
+
   void encode(bool enable,
               bool ignore_overrides,
               bool clear_override,
@@ -851,6 +857,7 @@ class SteerCmdMsg :
 {
 public:
   static const uint32_t CAN_ID;
+  static const uint8_t DATA_LENGTH = 5;
 
   void encode(bool enabled,
               bool ignore_overrides,

--- a/include/pacmod3/pacmod3_core.h
+++ b/include/pacmod3/pacmod3_core.h
@@ -739,7 +739,7 @@ class SystemCmdBool :
   public Pacmod3RxMsg
 {
 public:
-  static const uint8_t DATA_LENGTH = 2;
+  static constexpr uint8_t DATA_LENGTH = 2;
 
   void encode(bool enable,
               bool ignore_overrides,
@@ -752,7 +752,7 @@ class SystemCmdFloat :
   public Pacmod3RxMsg
 {
 public:
-  static const uint8_t DATA_LENGTH = 3;
+  static constexpr uint8_t DATA_LENGTH = 3;
 
   void encode(bool enable,
               bool ignore_overrides,
@@ -765,7 +765,7 @@ class SystemCmdInt :
   public Pacmod3RxMsg
 {
 public:
-  static const uint8_t DATA_LENGTH = 2;
+  static constexpr uint8_t DATA_LENGTH = 2;
 
   void encode(bool enable,
               bool ignore_overrides,
@@ -857,7 +857,7 @@ class SteerCmdMsg :
 {
 public:
   static const uint32_t CAN_ID;
-  static const uint8_t DATA_LENGTH = 5;
+  static constexpr uint8_t DATA_LENGTH = 5;
 
   void encode(bool enabled,
               bool ignore_overrides,

--- a/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -22,7 +22,7 @@ namespace PACMod3
 class LockedData
 {
 public:
-  LockedData();
+  explicit LockedData(unsigned char data_length);
 
   std::vector<unsigned char> getData() const;
   void setData(std::vector<unsigned char> new_data);

--- a/src/pacmod3_core.cpp
+++ b/src/pacmod3_core.cpp
@@ -820,7 +820,7 @@ void SystemCmdBool::encode(bool enable,
                            bool clear_faults,
                            bool cmd)
 {
-  data.assign(8, 0);
+  data.assign(DATA_LENGTH, 0);
 
   data[0] = (enable ? 0x01 : 0x00);
   data[0] |= (ignore_overrides ? 0x02 : 0x00);
@@ -835,7 +835,7 @@ void SystemCmdFloat::encode(bool enable,
                             bool clear_faults,
                             float cmd)
 {
-  data.assign(8, 0);
+  data.assign(DATA_LENGTH, 0);
 
   data[0] = enable ? 0x01 : 0x00;
   data[0] |= ignore_overrides ? 0x02 : 0x00;
@@ -853,7 +853,7 @@ void SystemCmdInt::encode(bool enable,
                           bool clear_faults,
                           uint8_t cmd)
 {
-  data.assign(8, 0);
+  data.assign(DATA_LENGTH, 0);
 
   data[0] = enable ? 0x01 : 0x00;
   data[0] |= ignore_overrides ? 0x02 : 0x00;
@@ -869,7 +869,7 @@ void SteerCmdMsg::encode(bool enable,
                          float steer_pos,
                          float steer_spd)
 {
-  data.assign(8, 0);
+  data.assign(DATA_LENGTH, 0);
 
   data[0] = enable ? 0x01 : 0x00;
   data[0] |= ignore_overrides ? 0x02 : 0x00;

--- a/src/pacmod3_core.cpp
+++ b/src/pacmod3_core.cpp
@@ -29,6 +29,11 @@ const uint32_t AS::Drivers::PACMod3::TurnSignalCmdMsg::CAN_ID = 0x130;
 const uint32_t AS::Drivers::PACMod3::WiperCmdMsg::CAN_ID = 0x134;
 const uint32_t AS::Drivers::PACMod3::RearPassDoorCmdMsg::CAN_ID = 0x140;
 
+const uint8_t AS::Drivers::PACMod3::SystemCmdBool::DATA_LENGTH;
+const uint8_t AS::Drivers::PACMod3::SystemCmdFloat::DATA_LENGTH;
+const uint8_t AS::Drivers::PACMod3::SystemCmdInt::DATA_LENGTH;
+const uint8_t AS::Drivers::PACMod3::SteerCmdMsg::DATA_LENGTH;
+
 // System Reports
 const uint32_t AS::Drivers::PACMod3::AccelRptMsg::CAN_ID = 0x200;
 const uint32_t AS::Drivers::PACMod3::BrakeRptMsg::CAN_ID = 0x204;

--- a/src/pacmod3_core.cpp
+++ b/src/pacmod3_core.cpp
@@ -29,10 +29,10 @@ const uint32_t AS::Drivers::PACMod3::TurnSignalCmdMsg::CAN_ID = 0x130;
 const uint32_t AS::Drivers::PACMod3::WiperCmdMsg::CAN_ID = 0x134;
 const uint32_t AS::Drivers::PACMod3::RearPassDoorCmdMsg::CAN_ID = 0x140;
 
-const uint8_t AS::Drivers::PACMod3::SystemCmdBool::DATA_LENGTH;
-const uint8_t AS::Drivers::PACMod3::SystemCmdFloat::DATA_LENGTH;
-const uint8_t AS::Drivers::PACMod3::SystemCmdInt::DATA_LENGTH;
-const uint8_t AS::Drivers::PACMod3::SteerCmdMsg::DATA_LENGTH;
+constexpr uint8_t AS::Drivers::PACMod3::SystemCmdBool::DATA_LENGTH;
+constexpr uint8_t AS::Drivers::PACMod3::SystemCmdFloat::DATA_LENGTH;
+constexpr uint8_t AS::Drivers::PACMod3::SystemCmdInt::DATA_LENGTH;
+constexpr uint8_t AS::Drivers::PACMod3::SteerCmdMsg::DATA_LENGTH;
 
 // System Reports
 const uint32_t AS::Drivers::PACMod3::AccelRptMsg::CAN_ID = 0x200;

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -415,12 +415,24 @@ int main(int argc, char *argv[])
   ros::Subscriber rear_pass_door_cmd_sub = n.subscribe("as_rx/rear_pass_door_cmd", 20, callback_rear_pass_door_set_cmd);
 
   // Populate rx list
-  rx_list.insert(std::make_pair(AccelCmdMsg::CAN_ID, new LockedData(AccelCmdMsg::DATA_LENGTH)));
-  rx_list.insert(std::make_pair(BrakeCmdMsg::CAN_ID, new LockedData(BrakeCmdMsg::DATA_LENGTH)));
-  rx_list.insert(std::make_pair(ShiftCmdMsg::CAN_ID, new LockedData(ShiftCmdMsg::DATA_LENGTH)));
-  rx_list.insert(std::make_pair(SteerCmdMsg::CAN_ID, new LockedData(SteerCmdMsg::DATA_LENGTH)));
-  rx_list.insert(std::make_pair(TurnSignalCmdMsg::CAN_ID, new LockedData(TurnSignalCmdMsg::DATA_LENGTH)));
-  rx_list.insert(std::make_pair(RearPassDoorCmdMsg::CAN_ID, new LockedData(RearPassDoorCmdMsg::DATA_LENGTH)));
+  rx_list.insert(std::make_pair(
+    AccelCmdMsg::CAN_ID,
+    std::shared_ptr<LockedData>(new LockedData(AccelCmdMsg::DATA_LENGTH))));
+  rx_list.insert(std::make_pair(
+    BrakeCmdMsg::CAN_ID,
+    std::shared_ptr<LockedData>(new LockedData(BrakeCmdMsg::DATA_LENGTH))));
+  rx_list.insert(std::make_pair(
+    ShiftCmdMsg::CAN_ID,
+    std::shared_ptr<LockedData>(new LockedData(ShiftCmdMsg::DATA_LENGTH))));
+  rx_list.insert(std::make_pair(
+    SteerCmdMsg::CAN_ID,
+    std::shared_ptr<LockedData>(new LockedData(SteerCmdMsg::DATA_LENGTH))));
+  rx_list.insert(std::make_pair(
+    TurnSignalCmdMsg::CAN_ID,
+    std::shared_ptr<LockedData>(new LockedData(TurnSignalCmdMsg::DATA_LENGTH))));
+  rx_list.insert(std::make_pair(
+    RearPassDoorCmdMsg::CAN_ID,
+    std::shared_ptr<LockedData>(new LockedData(RearPassDoorCmdMsg::DATA_LENGTH))));
 
   if (veh_type == VehicleType::POLARIS_GEM ||
       veh_type == VehicleType::POLARIS_RANGER ||
@@ -452,7 +464,9 @@ int main(int argc, char *argv[])
     wiper_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
         new ros::Subscriber(n.subscribe("as_rx/wiper_cmd", 20, callback_wiper_set_cmd)));
 
-    rx_list.insert(std::make_pair(WiperCmdMsg::CAN_ID, new LockedData(WiperCmdMsg::DATA_LENGTH)));
+    rx_list.insert(std::make_pair(
+      WiperCmdMsg::CAN_ID,
+      std::shared_ptr<LockedData>(new LockedData(WiperCmdMsg::DATA_LENGTH))));
   }
 
   if (veh_type == VehicleType::LEXUS_RX_450H ||
@@ -483,8 +497,12 @@ int main(int argc, char *argv[])
     horn_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
         new ros::Subscriber(n.subscribe("as_rx/horn_cmd", 20, callback_horn_set_cmd)));
 
-    rx_list.insert(std::make_pair(HeadlightCmdMsg::CAN_ID, new LockedData(HeadlightCmdMsg::DATA_LENGTH)));
-    rx_list.insert(std::make_pair(HornCmdMsg::CAN_ID, new LockedData(HeadlightCmdMsg::DATA_LENGTH)));
+    rx_list.insert(std::make_pair(
+      HeadlightCmdMsg::CAN_ID,
+      std::shared_ptr<LockedData>(new LockedData(HeadlightCmdMsg::DATA_LENGTH))));
+    rx_list.insert(std::make_pair(
+      HornCmdMsg::CAN_ID,
+      std::shared_ptr<LockedData>(new LockedData(HeadlightCmdMsg::DATA_LENGTH))));
   }
 
   if (veh_type == VehicleType::VEHICLE_4)

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -415,19 +415,12 @@ int main(int argc, char *argv[])
   ros::Subscriber rear_pass_door_cmd_sub = n.subscribe("as_rx/rear_pass_door_cmd", 20, callback_rear_pass_door_set_cmd);
 
   // Populate rx list
-  std::shared_ptr<LockedData> accel_data(new LockedData);
-  std::shared_ptr<LockedData> brake_data(new LockedData);
-  std::shared_ptr<LockedData> shift_data(new LockedData);
-  std::shared_ptr<LockedData> steer_data(new LockedData);
-  std::shared_ptr<LockedData> turn_data(new LockedData);
-  std::shared_ptr<LockedData> rear_pass_door_data(new LockedData);
-
-  rx_list.insert(std::make_pair(AccelCmdMsg::CAN_ID, accel_data));
-  rx_list.insert(std::make_pair(BrakeCmdMsg::CAN_ID, brake_data));
-  rx_list.insert(std::make_pair(ShiftCmdMsg::CAN_ID, shift_data));
-  rx_list.insert(std::make_pair(SteerCmdMsg::CAN_ID, steer_data));
-  rx_list.insert(std::make_pair(TurnSignalCmdMsg::CAN_ID, turn_data));
-  rx_list.insert(std::make_pair(RearPassDoorCmdMsg::CAN_ID, rear_pass_door_data));
+  rx_list.insert(std::make_pair(AccelCmdMsg::CAN_ID, new LockedData(AccelCmdMsg::DATA_LENGTH)));
+  rx_list.insert(std::make_pair(BrakeCmdMsg::CAN_ID, new LockedData(BrakeCmdMsg::DATA_LENGTH)));
+  rx_list.insert(std::make_pair(ShiftCmdMsg::CAN_ID, new LockedData(ShiftCmdMsg::DATA_LENGTH)));
+  rx_list.insert(std::make_pair(SteerCmdMsg::CAN_ID, new LockedData(SteerCmdMsg::DATA_LENGTH)));
+  rx_list.insert(std::make_pair(TurnSignalCmdMsg::CAN_ID, new LockedData(TurnSignalCmdMsg::DATA_LENGTH)));
+  rx_list.insert(std::make_pair(RearPassDoorCmdMsg::CAN_ID, new LockedData(RearPassDoorCmdMsg::DATA_LENGTH)));
 
   if (veh_type == VehicleType::POLARIS_GEM ||
       veh_type == VehicleType::POLARIS_RANGER ||
@@ -459,8 +452,7 @@ int main(int argc, char *argv[])
     wiper_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
         new ros::Subscriber(n.subscribe("as_rx/wiper_cmd", 20, callback_wiper_set_cmd)));
 
-    std::shared_ptr<LockedData> wiper_data(new LockedData);
-    rx_list.insert(std::make_pair(WiperCmdMsg::CAN_ID, wiper_data));
+    rx_list.insert(std::make_pair(WiperCmdMsg::CAN_ID, new LockedData(WiperCmdMsg::DATA_LENGTH)));
   }
 
   if (veh_type == VehicleType::LEXUS_RX_450H ||
@@ -491,11 +483,8 @@ int main(int argc, char *argv[])
     horn_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
         new ros::Subscriber(n.subscribe("as_rx/horn_cmd", 20, callback_horn_set_cmd)));
 
-    std::shared_ptr<LockedData> headlight_data(new LockedData);
-    std::shared_ptr<LockedData> horn_data(new LockedData);
-
-    rx_list.insert(std::make_pair(HeadlightCmdMsg::CAN_ID, headlight_data));
-    rx_list.insert(std::make_pair(HornCmdMsg::CAN_ID, horn_data));
+    rx_list.insert(std::make_pair(HeadlightCmdMsg::CAN_ID, new LockedData(HeadlightCmdMsg::DATA_LENGTH)));
+    rx_list.insert(std::make_pair(HornCmdMsg::CAN_ID, new LockedData(HeadlightCmdMsg::DATA_LENGTH)));
   }
 
   if (veh_type == VehicleType::VEHICLE_4)
@@ -522,63 +511,21 @@ int main(int argc, char *argv[])
 
   if (veh_type == VehicleType::VEHICLE_5)
   {
-    // cruise_control_buttons_rpt_pub = n.advertise<pacmod_msgs::SystemRptInt>(
-    //     "parsed_tx/cruise_control_buttons_rpt", 20);
-    // dash_controls_left_rpt_pub = n.advertise<pacmod_msgs::SystemRptInt>("parsed_tx/dash_controls_left_rpt", 20);
-    // dash_controls_right_rpt_pub = n.advertise<pacmod_msgs::SystemRptInt>("parsed_tx/dash_controls_right_rpt", 20);
-    // media_controls_rpt_pub = n.advertise<pacmod_msgs::SystemRptInt>("parsed_tx/media_controls_rpt", 20);
     occupancy_rpt_pub = n.advertise<pacmod_msgs::OccupancyRpt>("parsed_tx/occupancy_rpt", 20);
     interior_lights_rpt_pub = n.advertise<pacmod_msgs::InteriorLightsRpt>("parsed_tx/interior_lights_rpt", 20);
     door_rpt_pub = n.advertise<pacmod_msgs::DoorRpt>("parsed_tx/door_rpt", 20);
     rear_lights_rpt_pub = n.advertise<pacmod_msgs::RearLightsRpt>("parsed_tx/rear_lights_rpt", 20);
 
-    // pub_tx_list.insert(std::make_pair(CruiseControlButtonsRptMsg::CAN_ID, cruise_control_buttons_rpt_pub));
-    // pub_tx_list.insert(std::make_pair(DashControlsLeftRptMsg::CAN_ID, dash_controls_left_rpt_pub));
-    // pub_tx_list.insert(std::make_pair(DashControlsRightRptMsg::CAN_ID, dash_controls_right_rpt_pub));
-    // pub_tx_list.insert(std::make_pair(MediaControlsRptMsg::CAN_ID, media_controls_rpt_pub));
     pub_tx_list.insert(std::make_pair(OccupancyRptMsg::CAN_ID, occupancy_rpt_pub));
     pub_tx_list.insert(std::make_pair(InteriorLightsRptMsg::CAN_ID, interior_lights_rpt_pub));
     pub_tx_list.insert(std::make_pair(DoorRptMsg::CAN_ID, door_rpt_pub));
     pub_tx_list.insert(std::make_pair(RearLightsRptMsg::CAN_ID, rear_lights_rpt_pub));
-
-    // cruise_control_buttons_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
-    //     new ros::Subscriber(
-    //         n.subscribe("as_rx/cruise_control_buttons_cmd", 20, callback_cruise_control_buttons_set_cmd)));
-    // dash_controls_left_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
-    //     new ros::Subscriber(n.subscribe("as_rx/dash_controls_left_cmd", 20, callback_dash_controls_left_set_cmd)));
-    // dash_controls_right_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
-    //     new ros::Subscriber(n.subscribe("as_rx/dash_controls_right_cmd", 20, callback_dash_controls_right_set_cmd)));
-    // media_controls_set_cmd_sub = std::shared_ptr<ros::Subscriber>(
-    //     new ros::Subscriber(n.subscribe("as_rx/media_controls_cmd", 20, callback_media_controls_set_cmd)));
-
-    // std::shared_ptr<LockedData> cruise_control_buttons_data(new LockedData);
-    // std::shared_ptr<LockedData> dash_controls_left_data(new LockedData);
-    // std::shared_ptr<LockedData> dash_controls_right_data(new LockedData);
-    // std::shared_ptr<LockedData> media_controls_data(new LockedData);
-
-    // rx_list.insert(std::make_pair(CruiseControlButtonsCmdMsg::CAN_ID, cruise_control_buttons_data));
-    // rx_list.insert(std::make_pair(DashControlsLeftCmdMsg::CAN_ID, dash_controls_left_data));
-    // rx_list.insert(std::make_pair(DashControlsRightCmdMsg::CAN_ID, dash_controls_right_data));
-    // rx_list.insert(std::make_pair(MediaControlsCmdMsg::CAN_ID, media_controls_data));
   }
 
-  // Initialize rx_list with all 0s
-  for (auto rx_it = rx_list.begin(); rx_it != rx_list.end(); rx_it++)
-  {
-    if (rx_it->first == TurnSignalCmdMsg::CAN_ID)
-    {
-      // Turn signals have non-0 initial value.
-      TurnSignalCmdMsg turn_encoder;
-      turn_encoder.encode(false, false, false, false, pacmod_msgs::SystemCmdInt::TURN_NONE);
-      rx_it->second->setData(turn_encoder.data);
-    }
-    else
-    {
-      std::vector<uint8_t> empty_vec;
-      empty_vec.assign(8, 0);
-      rx_it->second->setData(empty_vec);
-    }
-  }
+  // Initialize Turn Signal with non-0 value
+  TurnSignalCmdMsg turn_encoder;
+  turn_encoder.encode(false, false, false, false, pacmod_msgs::SystemCmdInt::TURN_NONE);
+  rx_list[TurnSignalCmdMsg::CAN_ID]->setData(std::move(turn_encoder.data));
 
   // Set initial state
   set_enable(false);
@@ -623,7 +570,7 @@ int main(int argc, char *argv[])
       else if (system->first == TurnSignalRptMsg::CAN_ID)
         kvp.key = "Turn Signals";
       else if (system->first == RearPassDoorRptMsg::CAN_ID)
-        kvp.key = "RearPassDoor";
+        kvp.key = "Rear Passenger Door";
       else if (system->first == WiperRptMsg::CAN_ID)
         kvp.key = "Wipers";
 

--- a/src/pacmod3_ros_msg_handler.cpp
+++ b/src/pacmod3_ros_msg_handler.cpp
@@ -13,10 +13,11 @@
 
 using namespace AS::Drivers::PACMod3;  // NOLINT
 
-LockedData::LockedData() :
+LockedData::LockedData(unsigned char data_length) :
   _data(),
   _data_mut()
 {
+  _data.assign(data_length, 0);
 }
 
 std::vector<unsigned char> LockedData::getData() const


### PR DESCRIPTION
DATA_LENGTH is a property which defines the length of the data payload
on a given CAN message. This is now used to initialize command message
data storage.

When I made the driver "DLC-agnostic," I was really only concerned with the reading of messages. This fixes the writing of messages to match the new DLCs in the DBC.

- [x] Tested in vehicle