### PR TITLE
Only send received data types

### DIFF
--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -29,6 +29,7 @@
 #include <tuple>
 #include <string>
 #include <vector>
+#include <set>
 #include <algorithm>
 
 #include <std_msgs/Bool.h>


### PR DESCRIPTION
This PR changes the way the driver sends commands to the PacMod over the CAN bus.
Currently, the driver will populate a list of all possible CAN commands for a given vehicle type, and then send the entire list every loop. This is undesirable as it adds unnecessary traffic to the CAN bus.

These changes will instead only send CAN messages that were received at least once on the ROS subscriber side. Once a single message of a given type is received, it will be sent every loop as long as the driver is running.

Tested with Autoware and pacmod gamepad demo on a Lexus.