### PR TITLE
Don't set disable bit on rx in override states.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            cd ..
-            catkin build pacmod3 --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             source `find /opt/ros -name setup.bash | sort | head -1`
@@ -55,10 +49,34 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
+          name: Run Tests
           command: |
+            source `find /opt/ros -name setup.bash | sort | head -1`
             cd ..
-            catkin build pacmod3 --no-deps --make-args roslint
+            catkin run_tests --no-deps pacmod3
+            catkin_test_results
+    working_directory: ~/src
+
+  noetic:
+    docker:
+      - image: autonomoustuff/docker-builds:noetic-ros-base
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq
+            source `find /opt/ros -name setup.bash | sort | head -1`
+            rosdep install --from-paths . --ignore-src -y
+            cd ..
+            catkin init
+            catkin config --extend /opt/ros/$ROS_DISTRO
+      - run:
+          name: Build
+          command: |
+            source `find /opt/ros -name setup.bash | sort | head -1`
+            cd ..
+            catkin build
       - run:
           name: Run Tests
           command: |
@@ -74,3 +92,4 @@ workflows:
     jobs:
       - kinetic
       - melodic
+      - noetic

--- a/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace AS
 {

--- a/src/pacmod3_core.cpp
+++ b/src/pacmod3_core.cpp
@@ -20,6 +20,8 @@
 
 #include "pacmod3/pacmod3_core.h"
 
+#include <memory>
+
 namespace AS
 {
 namespace Drivers

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -274,6 +274,8 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
                                   dc_parser->command_timeout));
     }
 
+    // TODO - Update setting disable flag on commands based on firmware handling
+
     if (msg->id == GlobalRptMsg::CAN_ID)
     {
       auto dc_parser = std::dynamic_pointer_cast<GlobalRptMsg>(parser_class);
@@ -282,6 +284,7 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
       bool_pub_msg.data = (dc_parser->enabled);
       enabled_pub.publish(bool_pub_msg);
 
+      // Don't need to set disable flag on commands for override, handled by firmware
       // if (dc_parser->override_active ||
       if (dc_parser->pacmod_sys_fault_active)
         set_enable(false);
@@ -294,6 +297,7 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
       bool_pub_msg.data = (dc_parser->system_enabled);
       enabled_pub.publish(bool_pub_msg);
 
+      // Don't need to set disable flag on commands for override, handled by firmware
       // if (dc_parser->system_override_active ||
       if (dc_parser->system_fault_active)
         set_enable(false);

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -30,6 +30,8 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <memory>
+#include <utility>
 
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float64.h>
@@ -1030,7 +1032,7 @@ int main(int argc, char *argv[])
     }
   }
 
-  if(veh_type == VehicleType::LEXUS_RX_450H)
+  if (veh_type == VehicleType::LEXUS_RX_450H)
   {
     ros::Publisher global_rpt2_pub = n.advertise<pacmod3::GlobalRpt2>("parsed_tx/global_rpt2", 20);
     ros::Publisher estop_rpt_pub = n.advertise<pacmod3::EStopRpt>("parsed_tx/estop_rpt", 20);

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -280,8 +280,8 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
       bool_pub_msg.data = (dc_parser->enabled);
       enabled_pub.publish(bool_pub_msg);
 
-      if (dc_parser->override_active ||
-          dc_parser->pacmod_sys_fault_active)
+      // if (dc_parser->override_active ||
+      if (dc_parser->pacmod_sys_fault_active)
         set_enable(false);
     }
     else if (msg->id == GlobalRpt2Msg::CAN_ID)
@@ -292,8 +292,8 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
       bool_pub_msg.data = (dc_parser->system_enabled);
       enabled_pub.publish(bool_pub_msg);
 
-      if (dc_parser->system_override_active ||
-          dc_parser->system_fault_active)
+      // if (dc_parser->system_override_active ||
+      if (dc_parser->system_fault_active)
         set_enable(false);
     }
     else if (msg->id == VehicleSpeedRptMsg::CAN_ID)
@@ -897,7 +897,7 @@ int main(int argc, char *argv[])
       n.advertise<pacmod3::SystemRptBool>("parsed_tx/horn_rpt", 20);
     ros::Publisher turn_rpt_pub =
       n.advertise<pacmod3::SystemRptInt>("parsed_tx/turn_rpt", 20);
-    ros::Publisher wiper_rpt_pub = 
+    ros::Publisher wiper_rpt_pub =
       n.advertise<pacmod3::SystemRptInt>("parsed_tx/wiper_rpt", 20);
     ros::Publisher wheel_speed_rpt_pub =
       n.advertise<pacmod3::WheelSpeedRpt>("parsed_tx/wheel_speed_rpt", 20);


### PR DESCRIPTION
Newer DBCs handle faults and overrides at the firmware level, don't need to send a disable bit. Only commenting out overrides for now to keep release consistent for HCV, FTT, etc. Will eventually have to update this portion.