### PR TITLE
ROS2: Add parameter for PACMod DBC version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
             source /opt/ros/*/setup.bash
             cd ..
             colcon test --packages-select $CIRCLE_PROJECT_REPONAME
-            colcon test-result
+            colcon test-result --verbose
 
 jobs:
   foxy:

--- a/include/pacmod3/pacmod3_node.hpp
+++ b/include/pacmod3/pacmod3_node.hpp
@@ -120,6 +120,7 @@ private:
 
   VehicleType vehicle_type_;
   std::string frame_id_;
+  unsigned int dbc_major_version_;
   Pacmod3TxRosMsgHandler tx_handler_;
   std::map<unsigned int, std::tuple<bool, bool, bool>> system_statuses;
 

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -45,6 +45,7 @@ PACMod3Node::PACMod3Node(rclcpp::NodeOptions options)
 {
   std::string vehicle_type_string = this->declare_parameter("vehicle_type", "POLARIS_GEM");
   frame_id_ = this->declare_parameter("frame_id", "pacmod");
+  dbc_major_version_ = this->declare_parameter("dbc_major_version", 3);
 
   if (vehicle_type_string == "INTERNATIONAL_PROSTAR_122") {
     vehicle_type_ = VehicleType::INTERNATIONAL_PROSTAR_122;
@@ -70,8 +71,17 @@ PACMod3Node::PACMod3Node(rclcpp::NodeOptions options)
       "An invalid vehicle type was entered. Defaulting to POLARIS_GEM.");
   }
 
-  RCLCPP_INFO(this->get_logger(), "Got vehicle type: %s", vehicle_type_string.c_str());
-  RCLCPP_INFO(this->get_logger(), "Got frame id: %s", frame_id_.c_str());
+  RCLCPP_INFO(this->get_logger(), "vehicle_type: %s", vehicle_type_string.c_str());
+  RCLCPP_INFO(this->get_logger(), "frame_id: %s", frame_id_.c_str());
+  RCLCPP_INFO(this->get_logger(), "dbc_major_version: %d", dbc_major_version_);
+
+  if (dbc_major_version_ != 3)
+  {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "This driver currently only supports PACMod DBC version 3");
+    rclcpp::shutdown();
+  }
 }
 
 PACMod3Node::~PACMod3Node()

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -75,8 +75,7 @@ PACMod3Node::PACMod3Node(rclcpp::NodeOptions options)
   RCLCPP_INFO(this->get_logger(), "frame_id: %s", frame_id_.c_str());
   RCLCPP_INFO(this->get_logger(), "dbc_major_version: %d", dbc_major_version_);
 
-  if (dbc_major_version_ != 3)
-  {
+  if (dbc_major_version_ != 3) {
     RCLCPP_ERROR(
       this->get_logger(),
       "This driver currently only supports PACMod DBC version 3");


### PR DESCRIPTION
Resolves #84 by adding a parameter for specifying the DBC major version.