### PR TITLE
ROS2: Simplify topic names

### DIFF
--- a/include/pacmod3/pacmod3_node.hpp
+++ b/include/pacmod3/pacmod3_node.hpp
@@ -92,7 +92,7 @@ private:
   void callback_rear_pass_door_cmd(const pacmod_msgs::msg::SystemCmdInt::SharedPtr msg);
   void callback_shift_cmd(const pacmod_msgs::msg::SystemCmdInt::SharedPtr msg);
   void callback_sprayer_cmd(const pacmod_msgs::msg::SystemCmdBool::SharedPtr msg);
-  void callback_steer_cmd(const pacmod_msgs::msg::SteerSystemCmd::SharedPtr msg);
+  void callback_steering_cmd(const pacmod_msgs::msg::SteerSystemCmd::SharedPtr msg);
   void callback_turn_cmd(const pacmod_msgs::msg::SystemCmdInt::SharedPtr msg);
   void callback_wiper_cmd(const pacmod_msgs::msg::SystemCmdInt::SharedPtr msg);
 

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -146,8 +146,8 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
 
   can_subs_[SteerCmdMsg::CAN_ID] = std::make_pair(
     this->create_subscription<pacmod_msgs::msg::SteerSystemCmd>(
-      "steer_cmd", 20,
-      std::bind(&PACMod3Node::callback_steer_cmd, this, std::placeholders::_1)),
+      "steering_cmd", 20,
+      std::bind(&PACMod3Node::callback_steering_cmd, this, std::placeholders::_1)),
     std::shared_ptr<LockedData>(new LockedData(SteerCmdMsg::DATA_LENGTH)));
 
   can_subs_[TurnSignalCmdMsg::CAN_ID] = std::make_pair(
@@ -523,7 +523,7 @@ void PACMod3Node::callback_sprayer_cmd(const pacmod_msgs::msg::SystemCmdBool::Sh
   lookup_and_encode(SprayerCmdMsg::CAN_ID, msg);
 }
 
-void PACMod3Node::callback_steer_cmd(const pacmod_msgs::msg::SteerSystemCmd::SharedPtr msg)
+void PACMod3Node::callback_steering_cmd(const pacmod_msgs::msg::SteerSystemCmd::SharedPtr msg)
 {
   lookup_and_encode(SteerCmdMsg::CAN_ID, msg);
 }

--- a/src/pacmod3_node.cpp
+++ b/src/pacmod3_node.cpp
@@ -88,71 +88,71 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
   pub_can_rx_ = this->create_publisher<can_msgs::msg::Frame>("can_rx", 100);
 
   can_pubs_[GlobalRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::GlobalRpt>("parsed_tx/global_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::GlobalRpt>("global_rpt", 20);
   can_pubs_[ComponentRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::ComponentRpt>("parsed_tx/component_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::ComponentRpt>("component_rpt", 20);
   can_pubs_[AccelRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::SystemRptFloat>("parsed_tx/accel_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::SystemRptFloat>("accel_rpt", 20);
   can_pubs_[BrakeRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::SystemRptFloat>("parsed_tx/brake_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::SystemRptFloat>("brake_rpt", 20);
   can_pubs_[ShiftRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::SystemRptInt>("parsed_tx/shift_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::SystemRptInt>("shift_rpt", 20);
   can_pubs_[SteerRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::SystemRptFloat>("parsed_tx/steer_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::SystemRptFloat>("steering_rpt", 20);
   can_pubs_[TurnSignalRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::SystemRptInt>("parsed_tx/turn_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::SystemRptInt>("turn_rpt", 20);
   can_pubs_[AccelAuxRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::AccelAuxRpt>("parsed_tx/accel_aux_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::AccelAuxRpt>("accel_aux_rpt", 20);
   can_pubs_[BrakeAuxRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::BrakeAuxRpt>("parsed_tx/brake_aux_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::BrakeAuxRpt>("brake_aux_rpt", 20);
   can_pubs_[ShiftAuxRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::ShiftAuxRpt>("parsed_tx/shift_aux_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::ShiftAuxRpt>("shift_aux_rpt", 20);
   can_pubs_[SteerAuxRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::SteerAuxRpt>("parsed_tx/steer_aux_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::SteerAuxRpt>("steering_aux_rpt", 20);
   can_pubs_[TurnAuxRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::TurnAuxRpt>("parsed_tx/turn_aux_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::TurnAuxRpt>("turn_aux_rpt", 20);
   can_pubs_[VehicleSpeedRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::VehicleSpeedRpt>("parsed_tx/vehicle_speed_rpt", 20);
+    this->create_publisher<pacmod_msgs::msg::VehicleSpeedRpt>("vehicle_speed_rpt", 20);
   can_pubs_[VinRptMsg::CAN_ID] =
-    this->create_publisher<pacmod_msgs::msg::VinRpt>("parsed_tx/vin_rpt", 5);
+    this->create_publisher<pacmod_msgs::msg::VinRpt>("vin_rpt", 5);
 
   pub_enabled_ = this->create_publisher<std_msgs::msg::Bool>(
-    "as_tx/enabled", rclcpp::QoS(1).transient_local());
+    "enabled", rclcpp::QoS(1).transient_local());
   pub_vehicle_speed_ms_ = this->create_publisher<std_msgs::msg::Float64>(
-    "as_tx/vehicle_speed", 20);
+    "vehicle_speed", 20);
   pub_all_system_statuses_ = this->create_publisher<pacmod_msgs::msg::AllSystemStatuses>(
-    "as_tx/all_system_statuses", 20);
+    "all_system_statuses", 20);
 
   sub_can_tx_ = this->create_subscription<can_msgs::msg::Frame>(
     "can_tx", 100, std::bind(&PACMod3Node::callback_can_tx, this, std::placeholders::_1));
 
   can_subs_[AccelCmdMsg::CAN_ID] = std::make_pair(
     this->create_subscription<pacmod_msgs::msg::SystemCmdFloat>(
-      "as_rx/accel_cmd", 20,
+      "accel_cmd", 20,
       std::bind(&PACMod3Node::callback_accel_cmd, this, std::placeholders::_1)),
     std::shared_ptr<LockedData>(new LockedData(AccelCmdMsg::DATA_LENGTH)));
 
   can_subs_[BrakeCmdMsg::CAN_ID] = std::make_pair(
     this->create_subscription<pacmod_msgs::msg::SystemCmdFloat>(
-      "as_rx/brake_cmd", 20,
+      "brake_cmd", 20,
       std::bind(&PACMod3Node::callback_brake_cmd, this, std::placeholders::_1)),
     std::shared_ptr<LockedData>(new LockedData(BrakeCmdMsg::DATA_LENGTH)));
 
   can_subs_[ShiftCmdMsg::CAN_ID] = std::make_pair(
     this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-      "as_rx/shift_cmd", 20,
+      "shift_cmd", 20,
       std::bind(&PACMod3Node::callback_shift_cmd, this, std::placeholders::_1)),
     std::shared_ptr<LockedData>(new LockedData(ShiftCmdMsg::DATA_LENGTH)));
 
   can_subs_[SteerCmdMsg::CAN_ID] = std::make_pair(
     this->create_subscription<pacmod_msgs::msg::SteerSystemCmd>(
-      "as_rx/steer_cmd", 20,
+      "steer_cmd", 20,
       std::bind(&PACMod3Node::callback_steer_cmd, this, std::placeholders::_1)),
     std::shared_ptr<LockedData>(new LockedData(SteerCmdMsg::DATA_LENGTH)));
 
   can_subs_[TurnSignalCmdMsg::CAN_ID] = std::make_pair(
     this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-      "as_rx/turn_cmd", 20,
+      "turn_cmd", 20,
       std::bind(&PACMod3Node::callback_turn_cmd, this, std::placeholders::_1)),
     std::shared_ptr<LockedData>(new LockedData(TurnSignalCmdMsg::DATA_LENGTH)));
 
@@ -168,17 +168,17 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
     vehicle_type_ == VehicleType::FREIGHTLINER_CASCADIA)
   {
     can_pubs_[BrakeMotorRpt1Msg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::MotorRpt1>("parsed_tx/brake_rpt_detail_1", 20);
+      this->create_publisher<pacmod_msgs::msg::MotorRpt1>("brake_motor_rpt_1", 20);
     can_pubs_[BrakeMotorRpt2Msg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::MotorRpt2>("parsed_tx/brake_rpt_detail_2", 20);
+      this->create_publisher<pacmod_msgs::msg::MotorRpt2>("brake_motor_rpt_2", 20);
     can_pubs_[BrakeMotorRpt3Msg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::MotorRpt3>("parsed_tx/brake_rpt_detail_3", 20);
+      this->create_publisher<pacmod_msgs::msg::MotorRpt3>("brake_motor_rpt_3", 20);
     can_pubs_[SteerMotorRpt1Msg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::MotorRpt1>("parsed_tx/steering_rpt_detail_1", 20);
+      this->create_publisher<pacmod_msgs::msg::MotorRpt1>("steering_motor_rpt_1", 20);
     can_pubs_[SteerMotorRpt2Msg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::MotorRpt2>("parsed_tx/steering_rpt_detail_2", 20);
+      this->create_publisher<pacmod_msgs::msg::MotorRpt2>("steering_motor_rpt_2", 20);
     can_pubs_[SteerMotorRpt3Msg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::MotorRpt3>("parsed_tx/steering_rpt_detail_3", 20);
+      this->create_publisher<pacmod_msgs::msg::MotorRpt3>("steering_motor_rpt_3", 20);
   }
 
   if (
@@ -186,13 +186,13 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
     vehicle_type_ == VehicleType::FREIGHTLINER_CASCADIA)
   {
     can_pubs_[WiperRptMsg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::SystemRptInt>("parsed_tx/wiper_rpt", 20);
+      this->create_publisher<pacmod_msgs::msg::SystemRptInt>("wiper_rpt", 20);
     can_pubs_[WiperAuxRptMsg::CAN_ID] =
-      this->create_publisher<pacmod_msgs::msg::WiperAuxRpt>("parsed_tx/wiper_aux_rpt", 20);
+      this->create_publisher<pacmod_msgs::msg::WiperAuxRpt>("wiper_aux_rpt", 20);
 
     can_subs_[WiperCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-        "as_rx/wiper_cmd", 20,
+        "wiper_cmd", 20,
         std::bind(&PACMod3Node::callback_wiper_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(WiperCmdMsg::DATA_LENGTH)));
   }
@@ -206,38 +206,38 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
   {
     can_pubs_[DateTimeRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::DateTimeRpt>(
-      "parsed_tx/date_time_rpt", 20);
+      "date_time_rpt", 20);
     can_pubs_[HeadlightRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptInt>(
-      "parsed_tx/headlight_rpt", 20);
+      "headlight_rpt", 20);
     can_pubs_[HeadlightAuxRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::HeadlightAuxRpt>(
-      "parsed_tx/headlight_aux_rpt", 20);
+      "headlight_aux_rpt", 20);
     can_pubs_[HornRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptBool>(
-      "parsed_tx/horn_rpt", 20);
+      "horn_rpt", 20);
     can_pubs_[LatLonHeadingRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::LatLonHeadingRpt>(
-      "parsed_tx/lat_lon_heading_rpt", 20);
+      "lat_lon_heading_rpt", 20);
     can_pubs_[ParkingBrakeRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptBool>(
-      "parsed_tx/parking_brake_status_rpt", 20);
+      "parking_brake_rpt", 20);
     can_pubs_[WheelSpeedRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::WheelSpeedRpt>(
-      "parsed_tx/wheel_speed_rpt", 20);
+      "wheel_speed_rpt", 20);
     can_pubs_[YawRateRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::YawRateRpt>(
-      "parsed_tx/yaw_rate_rpt", 20);
+      "yaw_rate_rpt", 20);
 
     can_subs_[HeadlightCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-        "as_rx/headlight_cmd", 20,
+        "headlight_cmd", 20,
         std::bind(&PACMod3Node::callback_headlight_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(HeadlightCmdMsg::DATA_LENGTH)));
 
     can_subs_[HornCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdBool>(
-        "as_rx/horn_cmd", 20,
+        "horn_cmd", 20,
         std::bind(&PACMod3Node::callback_horn_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(HornCmdMsg::DATA_LENGTH)));
   }
@@ -245,47 +245,47 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
   if (vehicle_type_ == VehicleType::FREIGHTLINER_CASCADIA) {
     can_pubs_[CruiseControlButtonsRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptInt>(
-      "parsed_tx/cruise_control_buttons_rpt", 20);
+      "cruise_control_buttons_rpt", 20);
     can_pubs_[EngineBrakeRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptInt>(
-      "parsed_tx/engine_brake_rpt", 20);
+      "engine_brake_rpt", 20);
     can_pubs_[MarkerLampRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptBool>(
-      "parsed_tx/marker_lamp_rpt", 20);
+      "marker_lamp_rpt", 20);
     can_pubs_[SprayerRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptBool>(
-      "parsed_tx/sprayer_rpt", 20);
+      "sprayer_rpt", 20);
     can_pubs_[HazardLightRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::SystemRptBool>(
-      "parsed_tx/hazard_lights_rpt", 20);
+      "hazard_lights_rpt", 20);
 
     can_subs_[CruiseControlButtonsCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-        "as_rx/cruise_control_buttons_cmd", 20,
+        "cruise_control_buttons_cmd", 20,
         std::bind(&PACMod3Node::callback_cruise_control_buttons_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(CruiseControlButtonsCmdMsg::DATA_LENGTH)));
 
     can_subs_[EngineBrakeCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-        "as_rx/engine_brake_cmd", 20,
+        "engine_brake_cmd", 20,
         std::bind(&PACMod3Node::callback_engine_brake_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(EngineBrakeCmdMsg::DATA_LENGTH)));
 
     can_subs_[MarkerLampCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdBool>(
-        "as_rx/marker_lamp_cmd", 20,
+        "marker_lamp_cmd", 20,
         std::bind(&PACMod3Node::callback_marker_lamp_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(MarkerLampCmdMsg::DATA_LENGTH)));
 
     can_subs_[SprayerCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdBool>(
-        "as_rx/sprayer_cmd", 20,
+        "sprayer_cmd", 20,
         std::bind(&PACMod3Node::callback_sprayer_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(SprayerCmdMsg::DATA_LENGTH)));
 
     can_subs_[HazardLightCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdBool>(
-        "as_rx/hazard_lights_cmd", 20,
+        "hazard_lights_cmd", 20,
         std::bind(&PACMod3Node::callback_hazard_lights_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(HazardLightCmdMsg::DATA_LENGTH)));
   }
@@ -293,7 +293,7 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
   if (vehicle_type_ == VehicleType::JUPITER_SPIRIT) {
     can_subs_[RearPassDoorCmdMsg::CAN_ID] = std::make_pair(
       this->create_subscription<pacmod_msgs::msg::SystemCmdInt>(
-        "as_rx/rear_pass_door_cmd", 20,
+        "rear_pass_door_cmd", 20,
         std::bind(&PACMod3Node::callback_rear_pass_door_cmd, this, std::placeholders::_1)),
       std::shared_ptr<LockedData>(new LockedData(RearPassDoorCmdMsg::DATA_LENGTH)));
   }
@@ -301,25 +301,25 @@ LNI::CallbackReturn PACMod3Node::on_configure(const lc::State & state)
   if (vehicle_type_ == VehicleType::VEHICLE_4) {
     can_pubs_[DetectedObjectRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::DetectedObjectRpt>(
-      "parsed_tx/detected_object_rpt", 20);
+      "detected_object_rpt", 20);
     can_pubs_[VehicleDynamicsRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::VehicleDynamicsRpt>(
-      "parsed_tx/vehicle_dynamics_rpt", 20);
+      "vehicle_dynamics_rpt", 20);
   }
 
   if (vehicle_type_ == VehicleType::VEHICLE_5) {
     can_pubs_[DoorRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::DoorRpt>(
-      "parsed_tx/door_rpt", 20);
+      "door_rpt", 20);
     can_pubs_[InteriorLightsRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::InteriorLightsRpt>(
-      "parsed_tx/interior_lights_rpt", 20);
+      "interior_lights_rpt", 20);
     can_pubs_[OccupancyRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::OccupancyRpt>(
-      "parsed_tx/occupancy_rpt", 20);
+      "occupancy_rpt", 20);
     can_pubs_[RearLightsRptMsg::CAN_ID] =
       this->create_publisher<pacmod_msgs::msg::RearLightsRpt>(
-      "parsed_tx/rear_lights_rpt", 20);
+      "rear_lights_rpt", 20);
   }
 
   pub_thread_ = std::make_shared<std::thread>();


### PR DESCRIPTION
Resolves #91 by simplifying topic names.
For the most part, the extra namespaces (`as_rx` and `parsed_tx`) were dropped.
In some cases, the name was changed slightly to match the latest DBC 11 terminology. For example `brake_rpt_detail_1` changed to `brake_motor_rpt_1`.