### PR TITLE
Improve minimal publishing changes

### DIFF
--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -471,12 +471,15 @@ void Pacmod3Nl::SystemStatusUpdate(const ros::TimerEvent& event)
 
 void Pacmod3Nl::can_write(const ros::TimerEvent& event)
 {
-  for (const auto& can_id : received_cmds)
+  // for (const auto& can_id : received_cmds)
+  for (const auto& element : rx_list)
   {
-    auto data = rx_list[can_id]->getData();
+    // auto data = rx_list[can_id]->getData();
+    auto data = element.second->getData();
 
     can_msgs::Frame frame;
-    frame.id = can_id;
+    // frame.id = can_id;
+    frame.id = element.first;
     frame.is_rtr = false;
     frame.is_extended = false;
     frame.is_error = false;

--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -471,15 +471,12 @@ void Pacmod3Nl::SystemStatusUpdate(const ros::TimerEvent& event)
 
 void Pacmod3Nl::can_write(const ros::TimerEvent& event)
 {
-  // for (const auto& can_id : received_cmds)
-  for (const auto& element : rx_list)
+  for (const auto& can_id : received_cmds)
   {
-    // auto data = rx_list[can_id]->getData();
-    auto data = element.second->getData();
+    auto data = rx_list[can_id]->getData();
 
     can_msgs::Frame frame;
-    // frame.id = can_id;
-    frame.id = element.first;
+    frame.id = can_id;
     frame.is_rtr = false;
     frame.is_extended = false;
     frame.is_error = false;

--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -269,6 +269,12 @@ void Pacmod3Nl::onInit()
     pub_tx_list.emplace(RearLightsRptMsg::CAN_ID, std::move(rear_lights_rpt_pub));
   }
 
+  // Init cmds to send, always init core subsystems with enable false
+  received_cmds.insert(AccelCmdMsg::CAN_ID);
+  received_cmds.insert(BrakeCmdMsg::CAN_ID);
+  received_cmds.insert(SteerCmdMsg::CAN_ID);
+  received_cmds.insert(ShiftCmdMsg::CAN_ID);
+
   // Initialize Turn Signal with non-0 value
   TurnSignalCmdMsg turn_encoder;
   turn_encoder.encode(false, false, false, pacmod3_msgs::SystemCmdInt::TURN_NONE);


### PR DESCRIPTION
Resolves #103 by always publishing accel, brake, steering, and shift commands right after startup.

This resolves the shifter problem since the driver is now guaranteed to send a disable before an enable on the shifter (this is a requirement in order to enable the system).
Ideally, I think this problem should be solved on the user side (pacmod_game_control), but this works for now and is more consistent with the way the driver used to work. I intend to update pacmod_game_control in the future anyway.