### PR TITLE
ROS1: Add strict version dependency on pacmod3_msgs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,7 @@
   <depend>nodelet</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
-  <depend>pacmod3_msgs</depend>
+  <depend version_gte="1.0.0" version_lt="1.1.0">pacmod3_msgs</depend>
   <depend>can_msgs</depend>
 
   <export>


### PR DESCRIPTION
Resolves #106 

This is what will prevent the driver from having a ROS msg mismatch problem. Once deployed via apt, apt will prevent `pacmod3_msgs` from being updated unless this `pacmod3` driver is ready to use the new msgs.