### PR TITLE
Add support for global rpt 2

### DIFF
--- a/include/pacmod3/pacmod3_core.h
+++ b/include/pacmod3/pacmod3_core.h
@@ -156,7 +156,7 @@ class GlobalRpt2Msg :
   public Pacmod3TxMsg
 {
 public:
-  static constexpr uint32_t CAN_ID = 0x17;
+  static constexpr uint32_t CAN_ID = 0x11;
 
   bool system_enabled;
   bool system_override_active;

--- a/include/pacmod3/pacmod3_core.h
+++ b/include/pacmod3/pacmod3_core.h
@@ -152,6 +152,20 @@ public:
   void parse(const uint8_t *in);
 };
 
+class GlobalRpt2Msg :
+  public Pacmod3TxMsg
+{
+public:
+  static constexpr uint32_t CAN_ID = 0x17;
+
+  bool system_enabled;
+  bool system_override_active;
+  bool system_fault_active;
+  bool supervisory_enable_required;
+
+  void parse(const uint8_t *in);
+};
+
 class ComponentRptMsg :
   public Pacmod3TxMsg
 {

--- a/include/pacmod3/pacmod3_nodelet.h
+++ b/include/pacmod3/pacmod3_nodelet.h
@@ -134,6 +134,7 @@ private:
   ros::Publisher can_rx_pub;
   ros::Publisher all_system_statuses_pub;
   ros::Publisher global_rpt_pub;
+  ros::Publisher global_rpt_2_pub;
   ros::Publisher component_rpt_pub;
   ros::Publisher accel_rpt_pub;
   ros::Publisher brake_rpt_pub;

--- a/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -33,6 +33,7 @@
 #include <pacmod3_msgs/SystemCmdFloat.h>
 #include <pacmod3_msgs/SystemCmdInt.h>
 #include <pacmod3_msgs/GlobalRpt.h>
+#include <pacmod3_msgs/GlobalRpt2.h>
 #include <pacmod3_msgs/AccelAuxRpt.h>
 #include <pacmod3_msgs/AllSystemStatuses.h>
 #include <pacmod3_msgs/BrakeAuxRpt.h>
@@ -102,6 +103,10 @@ private:
   void fillGlobalRpt(
       const std::shared_ptr<Pacmod3TxMsg>& parser_class,
       pacmod3_msgs::GlobalRpt * new_msg,
+      const std::string& frame_id);
+  void fillGlobalRpt2(
+      const std::shared_ptr<Pacmod3TxMsg>& parser_class,
+      pacmod3_msgs::GlobalRpt2 * new_msg,
       const std::string& frame_id);
   void fillComponentRpt(
       const std::shared_ptr<Pacmod3TxMsg>& parser_class,

--- a/src/pacmod3_core.cpp
+++ b/src/pacmod3_core.cpp
@@ -25,6 +25,7 @@ namespace pacmod3
 {
 
 constexpr uint32_t GlobalRptMsg::CAN_ID;
+constexpr uint32_t GlobalRpt2Msg::CAN_ID;
 constexpr uint32_t ComponentRptMsg::CAN_ID;
 
 // System Commands
@@ -150,6 +151,9 @@ std::shared_ptr<Pacmod3TxMsg> Pacmod3TxMsg::make_message(const uint32_t& can_id)
     break;
   case GlobalRptMsg::CAN_ID:
     return std::shared_ptr<Pacmod3TxMsg>(new GlobalRptMsg);
+    break;
+  case GlobalRpt2Msg::CAN_ID:
+    return std::shared_ptr<Pacmod3TxMsg>(new GlobalRpt2Msg);
     break;
   case HazardLightRptMsg::CAN_ID:
     return std::shared_ptr<Pacmod3TxMsg>(new HazardLightRptMsg);
@@ -304,6 +308,14 @@ void GlobalRptMsg::parse(const uint8_t *in)
   subsystem_can_timeout = ((in[0] & 0x20) > 0);
   vehicle_can_timeout = ((in[0] & 0x40) > 0);
   user_can_read_errors = ((in[6] << 8) | in[7]);
+}
+
+void GlobalRpt2Msg::parse(const uint8_t *in)
+{
+  system_enabled = in[0] & 0x01;
+  system_override_active = ((in[0] & 0x02) > 0);
+  system_fault_active = ((in[0] & 0x04) > 0);
+  supervisory_enable_required = ((in[0] & 0x08) > 0);
 }
 
 void ComponentRptMsg::parse(const uint8_t *in)

--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -45,6 +45,7 @@ void Pacmod3Nl::onInit()
   all_system_statuses_pub = nh_.advertise<pacmod3_msgs::AllSystemStatuses>("all_system_statuses", 20);
 
   global_rpt_pub = nh_.advertise<pacmod3_msgs::GlobalRpt>("global_rpt", 20);
+  global_rpt_2_pub = nh_.advertise<pacmod3_msgs::GlobalRpt>("global_rpt_2", 20);
   component_rpt_pub = nh_.advertise<pacmod3_msgs::ComponentRpt>("component_rpt", 20);
   accel_rpt_pub = nh_.advertise<pacmod3_msgs::SystemRptFloat>("accel_rpt", 20);
   brake_rpt_pub = nh_.advertise<pacmod3_msgs::SystemRptFloat>("brake_rpt", 20);
@@ -60,6 +61,7 @@ void Pacmod3Nl::onInit()
   vin_rpt_pub = nh_.advertise<pacmod3_msgs::VinRpt>("vin_rpt", 5);
 
   pub_tx_list.emplace(GlobalRptMsg::CAN_ID, std::move(global_rpt_pub));
+  pub_tx_list.emplace(GlobalRpt2Msg::CAN_ID, std::move(global_rpt_2_pub));
   pub_tx_list.emplace(ComponentRptMsg::CAN_ID, std::move(component_rpt_pub));
   pub_tx_list.emplace(AccelRptMsg::CAN_ID, std::move(accel_rpt_pub));
   pub_tx_list.emplace(BrakeRptMsg::CAN_ID, std::move(brake_rpt_pub));
@@ -636,9 +638,23 @@ void Pacmod3Nl::can_read(const can_msgs::Frame::ConstPtr &msg)
       bool_pub_msg.data = (dc_parser->enabled);
       enabled_pub.publish(bool_pub_msg);
 
-      if (dc_parser->override_active ||
-          dc_parser->fault_active)
+      if (dc_parser->override_active ||dc_parser->fault_active)
+      {
         set_enable(false);
+      }
+    }
+    if (msg->id == GlobalRpt2Msg::CAN_ID)
+    {
+      auto dc_parser = std::dynamic_pointer_cast<GlobalRpt2Msg>(parser_class);
+
+      std_msgs::Bool bool_pub_msg;
+      bool_pub_msg.data = (dc_parser->system_enabled);
+      enabled_pub.publish(bool_pub_msg);
+
+      if (dc_parser->system_override_active || dc_parser->system_fault_active)
+      {
+        set_enable(false);
+      }
     }
   }
 }

--- a/src/pacmod3_ros_msg_handler.cpp
+++ b/src/pacmod3_ros_msg_handler.cpp
@@ -333,6 +333,22 @@ void Pacmod3TxRosMsgHandler::fillGlobalRpt(
   new_msg->header.stamp = ros::Time::now();
 }
 
+void Pacmod3TxRosMsgHandler::fillGlobalRpt2(
+    const std::shared_ptr<Pacmod3TxMsg>& parser_class,
+    pacmod3_msgs::GlobalRpt2 * new_msg,
+    const std::string& frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<GlobalRpt2Msg>(parser_class);
+
+  new_msg->system_enabled = dc_parser->system_enabled;
+  new_msg->system_override_active = dc_parser->system_override_active;
+  new_msg->system_fault_active = dc_parser->system_fault_active;
+  new_msg->supervisory_enable_required = dc_parser->supervisory_enable_required;
+
+  new_msg->header.frame_id = frame_id;
+  new_msg->header.stamp = ros::Time::now();
+}
+
 void Pacmod3TxRosMsgHandler::fillComponentRpt(
     const std::shared_ptr<Pacmod3TxMsg>& parser_class,
     pacmod3_msgs::ComponentRpt * new_msg,


### PR DESCRIPTION
Quick patch for GLOBAL_REPORT_2 support. Was hoping to have this covered by the refactor, but this will get us by for now.

Tested with @kmushty-as in a Ford Transit.