### PR TITLE
ROS2: Change to Humble CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ commands:
             colcon test-result --verbose
 
 jobs:
-  foxy:
+  humble:
     docker:
-      - image: autonomoustuff/docker-builds:foxy-ros-base
+      - image: autonomoustuff/docker-builds:humble-ros-base
     steps:
       - ros_build
     working_directory: ~/src
@@ -42,4 +42,4 @@ jobs:
 workflows:
   ros_build:
     jobs:
-      - foxy
+      - humble


### PR DESCRIPTION
Resolves #126 by adding humble CI to the ros2_master branch.
foxy CI had to be removed since there are breaking code changes between foxy and humble (See https://github.com/astuff/pacmod3/pull/119).