### PR TITLE
2002.1.1 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package pacmod3
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update lifecycle API (`#119 <https://github.com/astuff/pacmod3/issues/119>`_)
+* Change to Humble CI (`#130 <https://github.com/astuff/pacmod3/issues/130>`_)
+* Contributors: Daisuke Nishimatsu, icolwell-as
+
 2002.1.0 (2022-03-04)
 ---------------------
 * Add rear pass door report (`#120 <https://github.com/astuff/pacmod3/issues/120>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package pacmod3
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2002.1.1 (2022-06-03)
+---------------------
 * Update lifecycle API (`#119 <https://github.com/astuff/pacmod3/issues/119>`_)
 * Change to Humble CI (`#130 <https://github.com/astuff/pacmod3/issues/130>`_)
 * Contributors: Daisuke Nishimatsu, icolwell-as

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pacmod3</name>
-  <version>2002.1.0</version>
+  <version>2002.1.1</version>
   <description>AutonomouStuff PACMod v3 Driver Package</description>
   <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Team</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
Resolves #131 by adding a new release for Humble.

CI is failing due to changes in the linter for Humble/Jammy, we can ignore for now.