### PR TITLE
Support later DBCs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,23 @@ add_library(pacmod3_common
   pacmod3_common/src/pacmod3_dbc3_ros_api.cpp
   pacmod3_common/src/pacmod3_dbc4_ros_api.cpp
   pacmod3_common/src/pacmod3_dbc5_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc6_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc7_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc8_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc9_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc10_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc11_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc12_ros_api.cpp
   pacmod3_common/src/autogen/pacmod3.c
   pacmod3_common/src/autogen/pacmod4.c
   pacmod3_common/src/autogen/pacmod5.c
+  pacmod3_common/src/autogen/pacmod6.c
+  pacmod3_common/src/autogen/pacmod7.c
+  pacmod3_common/src/autogen/pacmod8.c
+  pacmod3_common/src/autogen/pacmod9.c
+  pacmod3_common/src/autogen/pacmod10.c
+  pacmod3_common/src/autogen/pacmod11.c
+  pacmod3_common/src/autogen/pacmod12.c
 )
 
 # nodelets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,10 @@ add_library(pacmod3_common
   pacmod3_common/src/pacmod3_dbc_ros_api.cpp
   pacmod3_common/src/pacmod3_dbc3_ros_api.cpp
   pacmod3_common/src/pacmod3_dbc4_ros_api.cpp
+  pacmod3_common/src/pacmod3_dbc5_ros_api.cpp
   pacmod3_common/src/autogen/pacmod3.c
   pacmod3_common/src/autogen/pacmod4.c
+  pacmod3_common/src/autogen/pacmod5.c
 )
 
 # nodelets

--- a/README.md
+++ b/README.md
@@ -62,30 +62,32 @@ Topics published on supported platforms only:
 - `brake_motor_rpt_1` ([pacmod3_msgs/MotorRpt1](https://github.com/astuff/pacmod3_msgs/blob/master/msg/MotorRpt1.msg))
 - `brake_motor_rpt_2` ([pacmod3_msgs/MotorRpt2](https://github.com/astuff/pacmod3_msgs/blob/master/msg/MotorRpt2.msg))
 - `brake_motor_rpt_3` ([pacmod3_msgs/MotorRpt3](https://github.com/astuff/pacmod3_msgs/blob/master/msg/MotorRpt3.msg))
+- `cruise_control_buttons_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
+- `date_time_rpt` ([pacmod3_msgs/DateTimeRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/DateTimeRpt.msg))
+- `detected_object_rpt` ([pacmod3_msgs/DetectedObjectRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/DetectedObjectRpt.msg))
+- `door_rpt` ([pacmod3_msgs/DoorRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/DoorRpt.msg))
+- `estop_rpt` ([pacmod3_msgs/EStopRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/EStopRpt.msg))
+- `global_rpt_2` ([pacmod3_msgs/GlobalRpt2](https://github.com/astuff/pacmod3_msgs/blob/master/msg/GlobalRpt2.msg))
+- `engine_brake_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
+- `hazard_lights_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
+- `headlight_aux_rpt` ([pacmod3_msgs/HeadlightAuxRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/HeadlightAuxRpt.msg))
+- `headlight_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
+- `horn_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
+- `interior_lights_rpt` ([pacmod3_msgs/InteriorLightsRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/InteriorLightsRpt.msg))
+- `lat_lon_heading_rpt` ([pacmod3_msgs/LatLonHeadingRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/LatLonHeadingRpt.msg))
+- `marker_lamp_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
+- `occupancy_rpt` ([pacmod3_msgs/OccupancyRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/OccupancyRpt.msg))
+- `parking_brake_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
+- `rear_lights_rpt` ([pacmod3_msgs/RearLightsRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/RearLightsRpt.msg))
+- `sprayer_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
 - `steering_motor_rpt_1` ([pacmod3_msgs/MotorRpt1](https://github.com/astuff/pacmod3_msgs/blob/master/msg/MotorRpt1.msg))
 - `steering_motor_rpt_2` ([pacmod3_msgs/MotorRpt2](https://github.com/astuff/pacmod3_msgs/blob/master/msg/MotorRpt2.msg))
 - `steering_motor_rpt_3` ([pacmod3_msgs/MotorRpt3](https://github.com/astuff/pacmod3_msgs/blob/master/msg/MotorRpt3.msg))
-- `wiper_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
-- `wiper_aux_rpt` ([pacmod3_msgs/WiperAuxRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/WiperAuxRpt.msg))
-- `headlight_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
-- `headlight_aux_rpt` ([pacmod3_msgs/HeadlightAuxRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/HeadlightAuxRpt.msg))
-- `horn_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
-- `wheel_speed_rpt` ([pacmod3_msgs/WheelSpeedRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/WheelSpeedRpt.msg))
-- `parking_brake_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
-- `door_rpt` ([pacmod3_msgs/DoorRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/DoorRpt.msg))
-- `interior_lights_rpt` ([pacmod3_msgs/InteriorLightsRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/InteriorLightsRpt.msg))
-- `occupancy_rpt` ([pacmod3_msgs/OccupancyRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/OccupancyRpt.msg))
-- `rear_lights_rpt` ([pacmod3_msgs/RearLightsRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/RearLightsRpt.msg))
-- `hazard_lights_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
-- `date_time_rpt` ([pacmod3_msgs/DateTimeRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/DateTimeRpt.msg))
-- `lat_lon_heading_rpt` ([pacmod3_msgs/LatLonHeadingRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/LatLonHeadingRpt.msg))
-- `yaw_rate_rpt` ([pacmod3_msgs/YawRateRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/YawRateRpt.msg))
-- `cruise_control_buttons_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
-- `engine_brake_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
-- `marker_lamp_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
-- `sprayer_rpt` ([pacmod3_msgs/SystemRptBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptBool.msg))
-- `detected_object_rpt` ([pacmod3_msgs/DetectedObjectRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/DetectedObjectRpt.msg))
 - `vehicle_dynamics_rpt` ([pacmod3_msgs/VehicleDynamicsRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/VehicleDynamicsRpt.msg))
+- `wheel_speed_rpt` ([pacmod3_msgs/WheelSpeedRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/WheelSpeedRpt.msg))
+- `wiper_aux_rpt` ([pacmod3_msgs/WiperAuxRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/WiperAuxRpt.msg))
+- `wiper_rpt` ([pacmod3_msgs/SystemRptInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemRptInt.msg))
+- `yaw_rate_rpt` ([pacmod3_msgs/YawRateRpt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/YawRateRpt.msg))
 
 ### Subscribed Topics
 
@@ -100,20 +102,20 @@ Topics subscribed on all platforms:
 
 Topics subscribed on supported platforms only:
 
-- `wiper_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
-- `headlight_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
-- `horn_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
-- `hazard_lights_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
 - `cruise_control_buttons_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
 - `engine_brake_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
+- `hazard_lights_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
+- `headlight_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
+- `horn_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
 - `marker_lamp_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
-- `sprayer_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
 - `rear_pass_door_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
+- `sprayer_cmd` ([pacmod3_msgs/SystemCmdBool](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdBool.msg))
+- `wiper_cmd` ([pacmod3_msgs/SystemCmdInt](https://github.com/astuff/pacmod3_msgs/blob/master/msg/SystemCmdInt.msg))
 
 ## Supported Vehicles ##
 
-At the moment, this pacmod3 driver only supports vehicles that use DBC version 3.
-The majority of existing Lexus platforms use DBC version 3.
-However, recently-purchased vehicle platforms (including Lexus) use a newer DBC version.
+At the moment, this pacmod3 driver supports DBC versions 3 through 12 for a core set of common messages.
+This means not all vehicle-specific CAN messages are currently supported.
+If you need a specific CAN message to be supported please open an issue [here](https://github.com/astuff/pacmod3/issues).
 
 If you are unsure about which DBC version your existing PACMod supports, please reach out to our support team: https://autonomoustuff.com/support

--- a/include/pacmod3/pacmod3_nodelet.h
+++ b/include/pacmod3/pacmod3_nodelet.h
@@ -96,6 +96,7 @@ private:
   void initializeRearLightsRptApi();
   void initializeHazardLightApi();
   void initializeEStopRptApi();
+  void initializeGlobalRpt2Api();
 
   // Vehicle-specific APIs
   void initializeLexusSpecificApi();

--- a/include/pacmod3/pacmod3_nodelet.h
+++ b/include/pacmod3/pacmod3_nodelet.h
@@ -34,10 +34,6 @@
 #include <nodelet/nodelet.h>
 
 #include <can_msgs/Frame.h>
-#include <pacmod3_msgs/SystemCmdBool.h>
-#include <pacmod3_msgs/SystemCmdFloat.h>
-#include <pacmod3_msgs/SystemCmdInt.h>
-#include <pacmod3_msgs/GlobalRpt.h>
 #include <pacmod3_msgs/AccelAuxRpt.h>
 #include <pacmod3_msgs/AllSystemStatuses.h>
 #include <pacmod3_msgs/BrakeAuxRpt.h>
@@ -45,7 +41,9 @@
 #include <pacmod3_msgs/DateTimeRpt.h>
 #include <pacmod3_msgs/DetectedObjectRpt.h>
 #include <pacmod3_msgs/DoorRpt.h>
+#include <pacmod3_msgs/EStopRpt.h>
 #include <pacmod3_msgs/EngineRpt.h>
+#include <pacmod3_msgs/GlobalRpt.h>
 #include <pacmod3_msgs/HeadlightAuxRpt.h>
 #include <pacmod3_msgs/InteriorLightsRpt.h>
 #include <pacmod3_msgs/LatLonHeadingRpt.h>
@@ -57,6 +55,9 @@
 #include <pacmod3_msgs/ShiftAuxRpt.h>
 #include <pacmod3_msgs/SteeringAuxRpt.h>
 #include <pacmod3_msgs/SteeringCmd.h>
+#include <pacmod3_msgs/SystemCmdBool.h>
+#include <pacmod3_msgs/SystemCmdFloat.h>
+#include <pacmod3_msgs/SystemCmdInt.h>
 #include <pacmod3_msgs/SystemRptBool.h>
 #include <pacmod3_msgs/SystemRptFloat.h>
 #include <pacmod3_msgs/SystemRptInt.h>
@@ -94,6 +95,7 @@ private:
   void initializeOccupancyRptApi();
   void initializeRearLightsRptApi();
   void initializeHazardLightApi();
+  void initializeEStopRptApi();
 
   // Vehicle-specific APIs
   void initializeLexusSpecificApi();

--- a/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -23,9 +23,7 @@
 
 
 #include "pacmod3_dbc_ros_api.h"
-#include "pacmod3_dbc3_ros_api.h"
-#include "pacmod3_dbc4_ros_api.h"
-#include "pacmod3_dbc5_ros_api.h"
+#include "pacmod3_dbc12_ros_api.h"
 
 #include <string>
 #include <vector>
@@ -33,42 +31,6 @@
 #include <mutex>
 
 #include <ros/ros.h>
-
-#include <can_msgs/Frame.h>
-#include <pacmod3_msgs/SystemCmdBool.h>
-#include <pacmod3_msgs/SystemCmdFloat.h>
-#include <pacmod3_msgs/SystemCmdInt.h>
-#include <pacmod3_msgs/GlobalRpt.h>
-#include <pacmod3_msgs/GlobalRpt2.h>
-#include <pacmod3_msgs/AccelAuxRpt.h>
-#include <pacmod3_msgs/AllSystemStatuses.h>
-#include <pacmod3_msgs/BrakeAuxRpt.h>
-#include <pacmod3_msgs/ComponentRpt.h>
-#include <pacmod3_msgs/DateTimeRpt.h>
-#include <pacmod3_msgs/DetectedObjectRpt.h>
-#include <pacmod3_msgs/DoorRpt.h>
-#include <pacmod3_msgs/EngineRpt.h>
-#include <pacmod3_msgs/HeadlightAuxRpt.h>
-#include <pacmod3_msgs/InteriorLightsRpt.h>
-#include <pacmod3_msgs/LatLonHeadingRpt.h>
-#include <pacmod3_msgs/MotorRpt1.h>
-#include <pacmod3_msgs/MotorRpt2.h>
-#include <pacmod3_msgs/MotorRpt3.h>
-#include <pacmod3_msgs/OccupancyRpt.h>
-#include <pacmod3_msgs/RearLightsRpt.h>
-#include <pacmod3_msgs/ShiftAuxRpt.h>
-#include <pacmod3_msgs/SteeringAuxRpt.h>
-#include <pacmod3_msgs/SteeringCmd.h>
-#include <pacmod3_msgs/SystemRptBool.h>
-#include <pacmod3_msgs/SystemRptFloat.h>
-#include <pacmod3_msgs/SystemRptInt.h>
-#include <pacmod3_msgs/TurnAuxRpt.h>
-#include <pacmod3_msgs/VehicleDynamicsRpt.h>
-#include <pacmod3_msgs/VehicleSpeedRpt.h>
-#include <pacmod3_msgs/VinRpt.h>
-#include <pacmod3_msgs/WheelSpeedRpt.h>
-#include <pacmod3_msgs/WiperAuxRpt.h>
-#include <pacmod3_msgs/YawRateRpt.h>
 
 namespace pacmod3
 {

--- a/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -25,6 +25,7 @@
 #include "pacmod3_dbc_ros_api.h"
 #include "pacmod3_dbc3_ros_api.h"
 #include "pacmod3_dbc4_ros_api.h"
+#include "pacmod3_dbc5_ros_api.h"
 
 #include <string>
 #include <vector>

--- a/launch/pacmod3.launch
+++ b/launch/pacmod3.launch
@@ -5,7 +5,7 @@
   <arg name="kvaser_circuit_id" default="0" />
   <arg name="use_socketcan" default="false" />
   <arg name="socketcan_device" default="can0" />
-  <arg name="dbc_major_version" default="5" />
+  <arg name="dbc_major_version" default="4" />
   <arg name="namespace" default="pacmod" />
 
   <group ns="$(arg namespace)">

--- a/launch/pacmod3.launch
+++ b/launch/pacmod3.launch
@@ -5,7 +5,7 @@
   <arg name="kvaser_circuit_id" default="0" />
   <arg name="use_socketcan" default="false" />
   <arg name="socketcan_device" default="can0" />
-  <arg name="dbc_major_version" default="4" />
+  <arg name="dbc_major_version" default="3" />
   <arg name="namespace" default="pacmod" />
 
   <group ns="$(arg namespace)">

--- a/launch/pacmod3.launch
+++ b/launch/pacmod3.launch
@@ -5,7 +5,7 @@
   <arg name="kvaser_circuit_id" default="0" />
   <arg name="use_socketcan" default="false" />
   <arg name="socketcan_device" default="can0" />
-  <arg name="dbc_major_version" default="3" />
+  <arg name="dbc_major_version" default="5" />
   <arg name="namespace" default="pacmod" />
 
   <group ns="$(arg namespace)">

--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -125,10 +125,10 @@ void Pacmod3Nl::onInit()
 void Pacmod3Nl::loadParams()
 {
   // Get and validate parameters
-  pnh_.param<int>("dbc_major_version", dbc_major_version_, 5);
-  if (dbc_major_version_ < 3 || dbc_major_version_ > 5)
+  pnh_.param<int>("dbc_major_version", dbc_major_version_, 4);
+  if (dbc_major_version_ < 3 || dbc_major_version_ > 12)
   {
-    NODELET_ERROR("This driver currently only supports PACMod DBC version 3 through 5");
+    NODELET_ERROR("This driver currently only supports PACMod DBC version 3 through 12");
     ros::shutdown();
   }
 }
@@ -273,6 +273,14 @@ void Pacmod3Nl::initializeEStopRptApi()
     nh_.advertise<pacmod3_msgs::EStopRpt>("estop_rpt", 20);
   pub_tx_list.emplace(ESTOP_RPT_CANID, std::move(estop_rpt_pub));
   NODELET_INFO("Initialized EStopRpt API");
+}
+
+void Pacmod3Nl::initializeGlobalRpt2Api()
+{
+  ros::Publisher global_rpt_2_pub =
+    nh_.advertise<pacmod3_msgs::GlobalRpt2>("global_rpt_2", 20);
+  pub_tx_list.emplace(GLOBAL_RPT_2_CANID, std::move(global_rpt_2_pub));
+  NODELET_INFO("Initialized GlobalRpt2 API");
 }
 
 void Pacmod3Nl::initializeLexusSpecificApi()
@@ -440,6 +448,10 @@ void Pacmod3Nl::initializeApiForMsg(uint32_t msg_can_id)
       {
         initializeEStopRptApi();
         break;
+      }
+    case GLOBAL_RPT_2_CANID:
+      {
+        initializeGlobalRpt2Api();
       }
     case DATE_TIME_RPT_CANID:
     case LAT_LON_HEADING_RPT_CANID:

--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -125,7 +125,7 @@ void Pacmod3Nl::onInit()
 void Pacmod3Nl::loadParams()
 {
   // Get and validate parameters
-  pnh_.param<int>("dbc_major_version", dbc_major_version_, 4);
+  pnh_.param<int>("dbc_major_version", dbc_major_version_, 3);
   if (dbc_major_version_ < 3 || dbc_major_version_ > 12)
   {
     NODELET_ERROR("This driver currently only supports PACMod DBC version 3 through 12");

--- a/src/pacmod3_nodelet.cpp
+++ b/src/pacmod3_nodelet.cpp
@@ -125,10 +125,10 @@ void Pacmod3Nl::onInit()
 void Pacmod3Nl::loadParams()
 {
   // Get and validate parameters
-  pnh_.param<int>("dbc_major_version", dbc_major_version_, 3);
-  if (dbc_major_version_ < 3 || dbc_major_version_ > 4)
+  pnh_.param<int>("dbc_major_version", dbc_major_version_, 5);
+  if (dbc_major_version_ < 3 || dbc_major_version_ > 5)
   {
-    NODELET_ERROR("This driver currently only supports PACMod DBC version 3 through 4");
+    NODELET_ERROR("This driver currently only supports PACMod DBC version 3 through 5");
     ros::shutdown();
   }
 }
@@ -265,6 +265,14 @@ void Pacmod3Nl::initializeHazardLightApi()
     HAZARD_LIGHTS_CMD_CANID,
     std::shared_ptr<LockedData>(new LockedData()));
   NODELET_INFO("Initialized HazardLight API");
+}
+
+void Pacmod3Nl::initializeEStopRptApi()
+{
+  ros::Publisher estop_rpt_pub =
+    nh_.advertise<pacmod3_msgs::EStopRpt>("estop_rpt", 20);
+  pub_tx_list.emplace(ESTOP_RPT_CANID, std::move(estop_rpt_pub));
+  NODELET_INFO("Initialized EStopRpt API");
 }
 
 void Pacmod3Nl::initializeLexusSpecificApi()
@@ -426,6 +434,11 @@ void Pacmod3Nl::initializeApiForMsg(uint32_t msg_can_id)
     case HAZARD_LIGHTS_RPT_CANID:
       {
         initializeHazardLightApi();
+        break;
+      }
+    case ESTOP_RPT_CANID:
+      {
+        initializeEStopRptApi();
         break;
       }
     case DATE_TIME_RPT_CANID:

--- a/src/pacmod3_ros_msg_handler.cpp
+++ b/src/pacmod3_ros_msg_handler.cpp
@@ -60,8 +60,29 @@ Pacmod3RosMsgHandler::Pacmod3RosMsgHandler(uint32_t dbc_major_version)
       msg_api_ = std::make_unique<pacmod3_common::Dbc4Api>();
       break;
     case (5):
-    default:
       msg_api_ = std::make_unique<pacmod3_common::Dbc5Api>();
+      break;
+    case (6):
+      msg_api_ = std::make_unique<pacmod3_common::Dbc6Api>();
+      break;
+    case (7):
+      msg_api_ = std::make_unique<pacmod3_common::Dbc7Api>();
+      break;
+    case (8):
+      msg_api_ = std::make_unique<pacmod3_common::Dbc8Api>();
+      break;
+    case (9):
+      msg_api_ = std::make_unique<pacmod3_common::Dbc9Api>();
+      break;
+    case (10):
+      msg_api_ = std::make_unique<pacmod3_common::Dbc10Api>();
+      break;
+    case (11):
+      msg_api_ = std::make_unique<pacmod3_common::Dbc11Api>();
+      break;
+    case (12):
+    default:
+      msg_api_ = std::make_unique<pacmod3_common::Dbc12Api>();
       break;
   }
   ROS_INFO("Initialized API for DBC version %d", msg_api_->GetDbcVersion());
@@ -108,9 +129,11 @@ Pacmod3RosMsgHandler::Pacmod3RosMsgHandler(uint32_t dbc_major_version)
   parse_functions[ENGINE_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseEngineRpt, std::ref(*msg_api_), std::placeholders::_1);
   parse_functions[ESTOP_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseEStopRpt, std::ref(*msg_api_), std::placeholders::_1);
   parse_functions[GLOBAL_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseGlobalRpt, std::ref(*msg_api_), std::placeholders::_1);
+  parse_functions[GLOBAL_RPT_2_CANID] = std::bind(&pacmod3_common::DbcApi::ParseGlobalRpt2, std::ref(*msg_api_), std::placeholders::_1);
   pub_functions[ENGINE_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::EngineRpt>, this, std::placeholders::_1, std::placeholders::_2);
   pub_functions[ESTOP_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::EStopRpt>, this, std::placeholders::_1, std::placeholders::_2);
   pub_functions[GLOBAL_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::GlobalRpt>, this, std::placeholders::_1, std::placeholders::_2);
+  pub_functions[GLOBAL_RPT_2_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::GlobalRpt2>, this, std::placeholders::_1, std::placeholders::_2);
 }
 
 void Pacmod3RosMsgHandler::ParseAndPublish(const can_msgs::Frame& can_msg, const ros::Publisher& pub)

--- a/src/pacmod3_ros_msg_handler.cpp
+++ b/src/pacmod3_ros_msg_handler.cpp
@@ -57,8 +57,11 @@ Pacmod3RosMsgHandler::Pacmod3RosMsgHandler(uint32_t dbc_major_version)
       msg_api_ = std::make_unique<pacmod3_common::Dbc3Api>();
       break;
     case (4):
-    default:
       msg_api_ = std::make_unique<pacmod3_common::Dbc4Api>();
+      break;
+    case (5):
+    default:
+      msg_api_ = std::make_unique<pacmod3_common::Dbc5Api>();
       break;
   }
   ROS_INFO("Initialized API for DBC version %d", msg_api_->GetDbcVersion());
@@ -102,10 +105,12 @@ Pacmod3RosMsgHandler::Pacmod3RosMsgHandler(uint32_t dbc_major_version)
   pub_functions[STEERING_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::SystemRptFloat>, this, std::placeholders::_1, std::placeholders::_2);
 
   // Other Reports
-  parse_functions[GLOBAL_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseGlobalRpt, std::ref(*msg_api_), std::placeholders::_1);
   parse_functions[ENGINE_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseEngineRpt, std::ref(*msg_api_), std::placeholders::_1);
-  pub_functions[GLOBAL_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::GlobalRpt>, this, std::placeholders::_1, std::placeholders::_2);
+  parse_functions[ESTOP_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseEStopRpt, std::ref(*msg_api_), std::placeholders::_1);
+  parse_functions[GLOBAL_RPT_CANID] = std::bind(&pacmod3_common::DbcApi::ParseGlobalRpt, std::ref(*msg_api_), std::placeholders::_1);
   pub_functions[ENGINE_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::EngineRpt>, this, std::placeholders::_1, std::placeholders::_2);
+  pub_functions[ESTOP_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::EStopRpt>, this, std::placeholders::_1, std::placeholders::_2);
+  pub_functions[GLOBAL_RPT_CANID] = std::bind(&Pacmod3RosMsgHandler::ParseAndPublishType<pacmod3_msgs::GlobalRpt>, this, std::placeholders::_1, std::placeholders::_2);
 }
 
 void Pacmod3RosMsgHandler::ParseAndPublish(const can_msgs::Frame& can_msg, const ros::Publisher& pub)


### PR DESCRIPTION
Resolves #135 by adding support for DBC versions 5 through 12. 
In doing so, the EStopRpt and GlobalRpt2 messages have also been added.
Also updated the README as needed.